### PR TITLE
Simplified Parse Function

### DIFF
--- a/libmp2t/stdafx.h
+++ b/libmp2t/stdafx.h
@@ -17,9 +17,9 @@
 #include <WinSock2.h>
 #include <crtdbg.h>
 
-#ifdef _DEBUG
+#ifdef _DEBUG_NEW
 #define DEBUG_CLIENTBLOCK   new( _CLIENT_BLOCK, __FILE__, __LINE__)
 #else
 #define DEBUG_CLIENTBLOCK
-#endif // _DEBUG
+#endif // _DEBUG_NEW
 #endif

--- a/libmp2t/tspckt.cpp
+++ b/libmp2t/tspckt.cpp
@@ -8,7 +8,7 @@
 #include <array>
 #include <cassert>
 
-#ifdef _DEBUG
+#ifdef _DEBUG_NEW
 #define new DEBUG_CLIENTBLOCK
 #endif
 

--- a/libmp2t/tspes.cpp
+++ b/libmp2t/tspes.cpp
@@ -6,7 +6,7 @@
 #include <arpa/inet.h>
 #endif
 
-#ifdef _DEBUG
+#ifdef _DEBUG_NEW
 #define new DEBUG_CLIENTBLOCK
 #endif
 

--- a/libmp2t/tspmt.cpp
+++ b/libmp2t/tspmt.cpp
@@ -9,7 +9,7 @@
 #include <arpa/inet.h>
 #endif
 
-#ifdef _DEBUG
+#ifdef _DEBUG_NEW
 #define new DEBUG_CLIENTBLOCK
 #endif
 

--- a/libmp2t/tsprsr.cpp
+++ b/libmp2t/tsprsr.cpp
@@ -40,29 +40,7 @@ void lcss::TSParser::parse(const BYTE* stream, UINT32 len)
 		// Malformed stream. Not on the 188 boundary. Find the sync byte.
 		if (*(stream + i) != 0x47)
 		{
-			// Find the sync byte
-			if (_pimpl->_tspckt.length() == 0) 
-			{
-				i++;
-			}
-			else // The TS packet spans across the stream buffer boundary
-			{
-				if (_pimpl->_packetSize == lcss::TransportPacket::TS_SIZE)
-				{
-					_pimpl->_tspckt.push_back(*(stream + i));
-					if (_pimpl->_tspckt.length() == lcss::TransportPacket::TS_SIZE)
-					{
-						onPacket(_pimpl->_tspckt);
-						_pimpl->_tspckt = lcss::TransportPacket();
-						_pimpl->_count++;
-					}
-					i++;
-				}
-				else // AVCHD format which can add 4 bytes to the TS packet
-				{
-					i += (_pimpl->_packetSize - lcss::TransportPacket::TS_SIZE);
-				}
-			}
+			i++;
 		}
 		// The TS packet is contain in the stream buffer
 		else if (i + lcss::TransportPacket::TS_SIZE <= len)
@@ -75,22 +53,10 @@ void lcss::TSParser::parse(const BYTE* stream, UINT32 len)
 				_pimpl->_tspckt = lcss::TransportPacket();
 				_pimpl->_count++;
 			}
-			else // False sync byte read.  Add byte to the packet.
-			{
-				_pimpl->_tspckt.push_back(*(stream + i));
-				if (_pimpl->_tspckt.length() == lcss::TransportPacket::TS_SIZE)
-				{
-					onPacket(_pimpl->_tspckt);
-					_pimpl->_tspckt = lcss::TransportPacket();
-					_pimpl->_count++;
-				}
-				i++;
-			}
 		}
 		// The TS packet spans across two stream buffers
 		else if (i + lcss::TransportPacket::TS_SIZE > len)
 		{
-			_pimpl->_tspckt.push_back(*(stream + i));
 			i++;
 		}
 	}


### PR DESCRIPTION
I simplified the parse function.
Disable memory checking in debug builds.  Require to define _DEBUG_NEW macro.