### PR TITLE
Add missing include to fix Linux build

### DIFF
--- a/libmp2t/tsmetadata.h
+++ b/libmp2t/tsmetadata.h
@@ -2,6 +2,7 @@
 
 #include "tstype.h"
 #include <vector>
+#include <cstddef>
 
 namespace lcss
 {


### PR DESCRIPTION
```
# in Ubuntu 22.04
~/mp2tp$ cmake --build .
Consolidate compiler generated dependencies of target libmp2t
[  7%] Building CXX object libmp2t/CMakeFiles/libmp2t.dir/tsmetadata.cpp.o
In file included from /home/imx/mp2tp/libmp2t/tsmetadata.cpp:2:
/home/user/mp2tp/libmp2t/tsmetadata.h:29:9: error: ‘size_t’ does not name a type
   29 |         size_t parse(BYTE* sodb, size_t len);
      |         ^~~~~~
/home/user/mp2tp/libmp2t/tsmetadata.h:5:1: note: ‘size_t’ is defined in header ‘<cstddef>’; did you forget to ‘#include <cstddef>’?
    4 | #include <vector>
  +++ |+#include <cstddef>
    5 | 
```

