### PR TITLE
Install mp2tpd.pdb file

### DIFF
--- a/mp2tp/CMakeLists.txt
+++ b/mp2tp/CMakeLists.txt
@@ -81,6 +81,10 @@ install (EXPORT mp2tp_export
     DESTINATION lib/cmake/mp2tp
 )
 
+if (WIN32)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/Debug/mp2tpd.pdb DESTINATION lib OPTIONAL)
+endif()
+
 # Defines write_basic_package_version_file
 include(CMakePackageConfigHelpers)
 


### PR DESCRIPTION
When installing debug version of mp2tp library, install the *.pdb file as well.