### PR TITLE
Handle Stream Errors

### DIFF
--- a/mp2tp/include/mp2tp/tsprsr.h
+++ b/mp2tp/include/mp2tp/tsprsr.h
@@ -29,7 +29,7 @@ namespace lcss
         /// <param name="size">The number of bytes in buf.</param>
         /// <returns>Return true if the function is able to parse the input stream
         /// in buf;otherwise return false.</returns>
-        virtual bool parse(const BYTE* buf, UINT32 size);
+        virtual bool parse(const BYTE* buf, UINT32 size, bool strict=false);
 
         /// <summary>
         /// A callback function that returns the most recent Transport 

--- a/mp2tp/include/mp2tp/tsprsr.h
+++ b/mp2tp/include/mp2tp/tsprsr.h
@@ -11,7 +11,7 @@ namespace lcss
     class TransportPacket;
 
     /// <summary>
-    /// TSParser decompose an input MPEG-2 TS stream into Transport Stream packets.
+    /// TSParser decompose an input MPEG-2 TS stream into Transport Stream (TS) packets.
     /// The client application uses this class to create a demultiplex process. 
     /// </summary>
     class TSParser
@@ -22,11 +22,15 @@ namespace lcss
 
         /// <summary>
         /// The function parses a MPEG-2 TS stream that is passed in as a raw 
-        /// byte sequence.  It decompose the stream into Transport Packets 
+        /// byte sequence in buf.  It decompose the stream into Transport Packets 
         /// that is provided onPacket function.
         /// </summary>
         /// <param name="buf">The raw byte sequence of a MPEG-2 TS stream.</param>
         /// <param name="size">The number of bytes in buf.</param>
+        /// <param name="strict">If false, the parse function will try to find the next
+        /// sync byte (0x47) in the stream; otherwise, if the sync byte is not on the 
+        /// TS Packet size boundary (usually 188 bytes), the parse function will return
+        /// false.</param>
         /// <returns>Return true if the function is able to parse the input stream
         /// in buf;otherwise return false.</returns>
         virtual bool parse(const BYTE* buf, UINT32 size, bool strict=false);

--- a/mp2tp/src/tsprsr.cpp
+++ b/mp2tp/src/tsprsr.cpp
@@ -39,7 +39,7 @@ lcss::TSParser::~TSParser()
 
 }
 
-bool lcss::TSParser::parse(const BYTE* stream, UINT32 len)
+bool lcss::TSParser::parse(const BYTE* stream, UINT32 len, bool strict)
 {
     uint32_t h = 0;
     uint32_t i = 0;
@@ -71,11 +71,14 @@ bool lcss::TSParser::parse(const BYTE* stream, UINT32 len)
         // The TS packet is contain in the stream buffer
         else if (i + lcss::TransportPacket::TS_SIZE <= len)
         {
-            if ( h != 0 && i - h != _pimpl->_packetSize && h != i)
+            if (strict)
             {
-                return false;
+                if (h != 0 && i - h != _pimpl->_packetSize && h != i)
+                {
+                    return false;
+                }
+                h = i;
             }
-            h = i;
 
             if (_pimpl->_buffer.size() == 0)
             {

--- a/mp2tp/src/tsprsr.cpp
+++ b/mp2tp/src/tsprsr.cpp
@@ -71,6 +71,7 @@ bool lcss::TSParser::parse(const BYTE* stream, UINT32 len, bool strict)
         // The TS packet is contain in the stream buffer
         else if (i + lcss::TransportPacket::TS_SIZE <= len)
         {
+            // Check to see if the sync byte falls on TS Packet size boundary
             if (strict)
             {
                 if (h != 0 && i - h != _pimpl->_packetSize && h != i)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -96,17 +96,29 @@ int main(int argc, char* argv[])
 
     BYTE memblock[N];
     int num_of_packets = 0;
+    std::streamsize bytesRead = 0;
+    bool strict = true;
+
     while (input->good())
     {
         input->read((char*)memblock, N);
-        bool result = decoder->parse(memblock, (unsigned)input->gcount());
+        bytesRead += input->gcount();
+        bool result = decoder->parse(memblock, (unsigned)input->gcount(), strict);
 
         if (!result)
         {
-            cerr << "Error: " << getFilename(ifile) << " is not a valid MPEG-2 TS file." << endl;
-            return -1;
+            if (bytesRead == N)
+            {
+                cerr << "Error: " << getFilename(ifile) << " is not a valid MPEG-2 TS file." << endl;
+                return -1;
+            }
+            else
+            {
+                cerr << "Error: " << "Parsing error in file, " << getFilename(ifile) << ", when " << bytesRead << " bytes were read" << endl;
+            }
         }
 
+        strict = false;
         num_of_packets += (int)input->gcount() / lcss::TransportPacket::TS_SIZE;
         if (canStop(num_of_packets, limit))
             break;


### PR DESCRIPTION
Had new bool parameter to TSParser::parse function.  If false, the parse function will try to find the next sync byte (0x47) in the stream; otherwise, if the sync byte is not on the TS Packet size boundary (usually 188 bytes), the parse function will return false.