### PR TITLE
Keep parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required (VERSION 3.21)
 
 project (mp2tp
-  VERSION 1.1.2
+  VERSION 1.1.3
   DESCRIPTION "MPEG-2 TS Parser library project."
   LANGUAGES CXX
 )

--- a/mp2tp/CMakeLists.txt
+++ b/mp2tp/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.21)
 
 project(mp2tp
-  VERSION 1.1.2
+  VERSION 1.1.3
   DESCRIPTION "MPEG-2 TS parser library"
   LANGUAGES CXX
 )

--- a/mp2tp/src/tsprsr.cpp
+++ b/mp2tp/src/tsprsr.cpp
@@ -40,6 +40,7 @@ bool lcss::TSParser::parse(const BYTE* stream, UINT32 len, bool strict)
 {
     uint32_t h = 0;
     uint32_t i = 0;
+    bool result = true;
 
     // The TS packet spans across two stream buffers
     if (_pimpl->_buffer.size() > 0 && _pimpl->_buffer.size() != lcss::TransportPacket::TS_SIZE)
@@ -76,7 +77,7 @@ bool lcss::TSParser::parse(const BYTE* stream, UINT32 len, bool strict)
                     i - h != _pimpl->_packetSize
                 )
                 {
-                    return false;
+                    result = false;
                 }
                 h = i;
             }
@@ -106,10 +107,10 @@ bool lcss::TSParser::parse(const BYTE* stream, UINT32 len, bool strict)
         if (_pimpl->_buffer.empty() && // TS Packet spans over two buffer reads so don't check
             i - h != _pimpl->_packetSize)
         {
-            return false;
+            result = false;
         }
     }
-    return true;
+    return result;
 }
 
 void lcss::TSParser::onPacket(lcss::TransportPacket& pckt)

--- a/src/TsWriter.h
+++ b/src/TsWriter.h
@@ -5,39 +5,39 @@
 
 namespace lcss
 {
-	class TransportPacket;
-	class AdaptationField;
-	class ProgramAssociationTable;
-	class ProgramMapTable;
-	class PESPacket;
-	class NetworkInformationTable;
+    class TransportPacket;
+    class AdaptationField;
+    class ProgramAssociationTable;
+    class ProgramMapTable;
+    class PESPacket;
+    class NetworkInformationTable;
 }
 
 namespace mp2tpser
 {
-	class TsWriter
-	{
-	private:
-		TsWriter();
+    class TsWriter
+    {
+    private:
+        TsWriter();
 
-		friend std::ostream& operator<<(std::ostream& ostrm, const lcss::ProgramAssociationTable& pat);
-		friend std::ostream& operator<<(std::ostream& ostrm, const lcss::ProgramMapTable& pat);
-		friend std::ostream& operator<<(std::ostream& ostrm, const lcss::PESPacket& pctk);
+        friend std::ostream& operator<<(std::ostream& ostrm, const lcss::ProgramAssociationTable& pat);
+        friend std::ostream& operator<<(std::ostream& ostrm, const lcss::ProgramMapTable& pat);
+        friend std::ostream& operator<<(std::ostream& ostrm, const lcss::PESPacket& pctk);
 
-	public:
-		static void printHeader(std::ostream& ostrm, const lcss::TransportPacket& pckt);
+    public:
+        static void printHeader(std::ostream& ostrm, const lcss::TransportPacket& pckt);
 
-	private:
-		static void printAdaptationField(std::ostream& ostrm, const lcss::AdaptationField& adf);
-		static std::string printPCR(std::ostream& ostrm, const lcss::AdaptationField& adf);
-		static void printPAT(std::ostream& ostrm, const lcss::ProgramAssociationTable& pat);
-		static void printPMT(std::ostream& ostrm, const lcss::ProgramMapTable& pmt);
-		static void printPES(std::ostream& ostrm, const lcss::PESPacket& pes);
-	};
+    private:
+        static void printAdaptationField(std::ostream& ostrm, const lcss::AdaptationField& adf);
+        static std::string printPCR(std::ostream& ostrm, const lcss::AdaptationField& adf);
+        static void printPAT(std::ostream& ostrm, const lcss::ProgramAssociationTable& pat);
+        static void printPMT(std::ostream& ostrm, const lcss::ProgramMapTable& pmt);
+        static void printPES(std::ostream& ostrm, const lcss::PESPacket& pes);
+    };
 
-	std::ostream& operator<<(std::ostream& ostrm, const lcss::ProgramAssociationTable& pat);
-	std::ostream& operator<<(std::ostream& ostrm, const lcss::ProgramMapTable& pat);
-	std::ostream& operator<<(std::ostream& ostrm, const lcss::PESPacket& pctk);
+    std::ostream& operator<<(std::ostream& ostrm, const lcss::ProgramAssociationTable& pat);
+    std::ostream& operator<<(std::ostream& ostrm, const lcss::ProgramMapTable& pat);
+    std::ostream& operator<<(std::ostream& ostrm, const lcss::PESPacket& pctk);
 }
 
 

--- a/tests/mp2tdmux/CMakeLists.txt
+++ b/tests/mp2tdmux/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required (VERSION 3.21)
 
 project(mp2tdmux
-  VERSION 1.1.2
+  VERSION 1.1.3
   DESCRIPTION "MPEG-2 TS Demultiplexor: creates a file for each elementary stream in the container."
   LANGUAGES CXX
 )


### PR DESCRIPTION
In TSParser::parse, If the MPEG-2 TS stream contains errors, keep parsing and return false.  Let the client code determine to stop parsing.  Usually, if the first buffer read the parse function returns false, stop because it is not an MPEG-2 TS stream.